### PR TITLE
(fix) Missing dependency: http-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "axios": "^0.15.0",
     "faker": "^3.1.0",
+    "http-server": "^0.9.0",
     "lazy-route": "^1.0.7",
     "mobx": "^2.5.2",
     "mobx-react": "^3.5.7",


### PR DESCRIPTION
After following the directions of...

`npm i`
`npm run preview`

I encountered the error:

`sh: http-server: command not found`

This PR adds http-server as a dependency so that `npm i` will gather everything it needs in order to work properly.