### PR TITLE
Fix Protected decorator name collision

### DIFF
--- a/src/components/Protected.js
+++ b/src/components/Protected.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { inject, observer } from "mobx-react";
 import { Redirect } from "react-router-dom";
 
-export default function Protected(Component) {
+export default function Protected(Children) {
 	@inject("store")
 	@observer
 	class AuthenticatedComponent extends Component {
@@ -16,7 +16,7 @@ export default function Protected(Component) {
 			return (
 				<div className="authComponent">
 					{authenticated
-						? <Component {...this.props} />
+						? <Children {...this.props} />
 						: !authenticating && !authenticated
 								? <Redirect
 										to={{


### PR DESCRIPTION
Right now there is a name collision in Protected decorator. It have  a Component as argument and then extends Component which is supposed to be a react Component but instead we extending Component passed to that decorator. This will lead to numerous problems, for example if there also inject decorator with Protected decorator it will lead to either double componentDidMount or warning.
