### PR TITLE
webpack: fix DEPRECATED warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,9 +61,15 @@ module.exports = {
                     {
                         loader: "image-webpack-loader",
                         options: {
-                            progressive: true,
-                            optimizationLevel: 7,
-                            interlaced: false,
+                            mozjpeg: {
+                                progressive: true,
+                            },
+                            optipng: {
+                                optimizationLevel: 7,
+                            },
+                            gifsicle: {
+                                interlaced: false,
+                            },
                             pngquant: {
                                 quality: "65-90",
                                 speed: 4

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -52,9 +52,15 @@ module.exports = {
                     {
                         loader: "image-webpack-loader",
                         options: {
-                            progressive: true,
-                            optimizationLevel: 7,
-                            interlaced: false,
+                            mozjpeg: {
+                                progressive: true,
+                            },
+                            optipng: {
+                                optimizationLevel: 7,
+                            },
+                            gifsicle: {
+                                interlaced: false,
+                            },
                             pngquant: {
                                 quality: "65-90",
                                 speed: 4


### PR DESCRIPTION
Fix lots of warnings:

```
WARNING in ./src/images/react_logo.svg
(Emitted value instead of an instance of Error) DEPRECATED. Configure gifsicle's interlaced option in its own options. (gifsicle.interlaced)
 @ ./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js?sourceMap!./src/styles/main.scss 6:4934-4969
 @ ./src/styles/main.scss
 @ ./src/index.js
 @ multi (webpack)-dev-server/client?http://0.0.0.0:3000 webpack/hot/dev-server react-hot-loader/patch webpack-dev-server/client?http://0.0.0.0:3000 webpack/hot/only-dev-server babel-polyfill whatwg-fetch ./src/index

WARNING in ./src/images/GitHub-Mark-Light-32px.png
(Emitted value instead of an instance of Error) DEPRECATED. Configure gifsicle's interlaced option in its own options. (gifsicle.interlaced)
 @ ./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js?sourceMap!./src/styles/main.scss 6:10654-10701
 @ ./src/styles/main.scss
 @ ./src/index.js
 @ multi (webpack)-dev-server/client?http://0.0.0.0:3000 webpack/hot/dev-server react-hot-loader/patch webpack-dev-server/client?http://0.0.0.0:3000 webpack/hot/only-dev-server babel-polyfill whatwg-fetch ./src/index

WARNING in ./src/images/GitHub-Mark-32px.png
(Emitted value instead of an instance of Error) DEPRECATED. Configure gifsicle's interlaced option in its own options. (gifsicle.interlaced)
 @ ./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js?sourceMap!./src/styles/main.scss 6:10364-10405
 @ ./src/styles/main.scss
 @ ./src/index.js
 @ multi (webpack)-dev-server/client?http://0.0.0.0:3000 webpack/hot/dev-server react-hot-loader/patch webpack-dev-server/client?http://0.0.0.0:3000 webpack/hot/only-dev-server babel-polyfill whatwg-fetch ./src/index

WARNING in ./src/images/reactrouter.png
(Emitted value instead of an instance of Error) DEPRECATED. Configure gifsicle's interlaced option in its own options. (gifsicle.interlaced)
 @ ./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js?sourceMap!./src/styles/main.scss 6:8689-8725
 @ ./src/styles/main.scss
 @ ./src/index.js
 @ multi (webpack)-dev-server/client?http://0.0.0.0:3000 webpack/hot/dev-server react-hot-loader/patch webpack-dev-server/client?http://0.0.0.0:3000 webpack/hot/only-dev-server babel-polyfill whatwg-fetch ./src/index

WARNING in ./src/images/react.png
(Emitted value instead of an instance of Error) DEPRECATED. Configure gifsicle's interlaced option in its own options. (gifsicle.interlaced)
 @ ./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js?sourceMap!./src/styles/main.scss 6:8286-8316
 @ ./src/styles/main.scss
 @ ./src/index.js
 @ multi (webpack)-dev-server/client?http://0.0.0.0:3000 webpack/hot/dev-server react-hot-loader/patch webpack-dev-server/client?http://0.0.0.0:3000 webpack/hot/only-dev-server babel-polyfill whatwg-fetch ./src/index```